### PR TITLE
sequence: use simple theme

### DIFF
--- a/src/sequence/index.html
+++ b/src/sequence/index.html
@@ -18,7 +18,7 @@
 
           // Generate SVG version of sequence
           var diagram = Diagram.parse(inputContent);
-          diagram.drawSVG("diagram", {theme: 'hand'});
+          diagram.drawSVG("diagram", {theme: 'simple'});
 
           // Write out the svg file
           fs.writeFileSync(options.outputPath, document.getElementById('diagram').innerHTML);


### PR DESCRIPTION
The sequence diagram type is not styled consistently with the diagrams. Using [the `simple` theme included in `js-sequence-diagrams`](https://github.com/bramp/js-sequence-diagrams/blob/b4e5244569f796886eb5dba269e2ebf8e96944a5/src/sequence-diagram.js#L624-L627) addresses this.